### PR TITLE
feat: Login/SignUp 수정

### DIFF
--- a/src/main/java/UMC/campusNote/auth/dto/JoinResDto.java
+++ b/src/main/java/UMC/campusNote/auth/dto/JoinResDto.java
@@ -8,10 +8,12 @@ import lombok.Getter;
 @Getter
 @Builder
 public class JoinResDto {
+    private Long userId;
     private String accesstoken;
     private String refreshtoken;
-    public static JoinResDto fromEntity(String accesstoken, String refreshtoken){
+    public static JoinResDto fromEntity(Long userId, String accesstoken, String refreshtoken){
         return JoinResDto.builder()
+                .userId(userId)
                 .accesstoken(accesstoken)
                 .refreshtoken(refreshtoken)
                 .build();

--- a/src/main/java/UMC/campusNote/auth/dto/LoginResDto.java
+++ b/src/main/java/UMC/campusNote/auth/dto/LoginResDto.java
@@ -10,11 +10,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class LoginResDto {
+    private Long userId;
     private String accessToken;
     private String refreshToken;
 
-    public static LoginResDto fromEntity(String accessToken, String refreshToken){
+    public static LoginResDto fromEntity(Long userId, String accessToken, String refreshToken){
         return LoginResDto.builder()
+                .userId(userId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/UMC/campusNote/auth/service/AuthServiceImpl.java
+++ b/src/main/java/UMC/campusNote/auth/service/AuthServiceImpl.java
@@ -31,6 +31,10 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public JoinResDto join(JoinReqDto joinReqDto) {
+        userRepository.findByClientId(joinReqDto.getClientId())
+                .ifPresent( user -> {
+                    throw new GeneralException(USER_ALREADY_EXIST);
+                });
         User user = joinReqDto.toEntity();
         User savedUser = userRepository.save(user);
         String accessToken = jwtProvider.generateToken(user);
@@ -42,7 +46,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public LoginResDto login(LoginReqDto loginReqDto) {
-        log.info("loginReqDto.getClientId() : {}", loginReqDto.getClientId());
+        //log.info("loginReqDto.getClientId() : {}", loginReqDto.getClientId());
         User user = userRepository.findByClientId(loginReqDto.getClientId())
                 .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
         String accessToken = jwtProvider.generateToken(user);

--- a/src/main/java/UMC/campusNote/auth/service/AuthServiceImpl.java
+++ b/src/main/java/UMC/campusNote/auth/service/AuthServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static UMC.campusNote.auth.jwt.JwtProvider.HEADER_AUTHORIZATION;
 import static UMC.campusNote.auth.jwt.JwtProvider.TOKEN_PREFIX;
+import static UMC.campusNote.common.code.status.ErrorStatus.USER_ALREADY_EXIST;
 import static UMC.campusNote.common.code.status.ErrorStatus.USER_NOT_FOUND;
 
 
@@ -35,7 +36,7 @@ public class AuthServiceImpl implements AuthService {
         String accessToken = jwtProvider.generateToken(user);
         String refreshToken = jwtProvider.generateRefreshToken(user);
         saveUserToken(savedUser, refreshToken);
-        return JoinResDto.fromEntity(accessToken, refreshToken);
+        return JoinResDto.fromEntity(savedUser.getId(), accessToken, refreshToken);
     }
 
     @Override
@@ -48,7 +49,7 @@ public class AuthServiceImpl implements AuthService {
         String refreshToken = jwtProvider.generateRefreshToken(user);
         revokeAllUserTokens(user);
         saveUserToken(user, refreshToken);
-        return LoginResDto.fromEntity(accessToken, refreshToken);
+        return LoginResDto.fromEntity(user.getId(), accessToken, refreshToken);
     }
 
     @Override


### PR DESCRIPTION
#34 
로그인과 회원가입에 관련된 api 기능을 수정(추가)했습니다.
1. signUp과 login의 response body에 id(user의 primary key) 값을 추가
    - 이유: 친구 추가 기능에 초대받는 사람 id와 초대하는 사람 id가 필요함
2. 회원가입에 이미 존재하는 회원일 경우, 예외처리 추가 