### PR TITLE
feat: 강의 노트 API 구현

### DIFF
--- a/src/main/java/UMC/campusNote/common/code/status/ErrorStatus.java
+++ b/src/main/java/UMC/campusNote/common/code/status/ErrorStatus.java
@@ -44,6 +44,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 노트 관련 에러
     NOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTE4001", "존재하지 않는 노트."),
+
+    // 강의 노트 관련 에러
+    LESSONNOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "LESSONNOTE4001", "존재하지 않는 강의 노트.")
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/UMC/campusNote/common/code/status/SuccessStatus.java
+++ b/src/main/java/UMC/campusNote/common/code/status/SuccessStatus.java
@@ -31,7 +31,10 @@ public enum SuccessStatus implements BaseCode {
     AUDIO_CREATE(HttpStatus.CREATED, "AUDIO201", "녹음 생성 성공"),
     AUDIO_GET_ALL(HttpStatus.OK, "AUDIO200", "녹음 파일 전체 조회 성공"),
     AUDIO_GET_ONE(HttpStatus.OK, "AUDIO200", "녹음 파일 조회 성공"),
-    AUDIO_DELETE(HttpStatus.OK, "AUDIO202", "녹음 파일 삭제 성공");
+    AUDIO_DELETE(HttpStatus.OK, "AUDIO202", "녹음 파일 삭제 성공"),
+
+    // 강의노트
+    LESSONNOTE_CREATE(HttpStatus.CREATED, "LESSONNOTE201", "강의노트 업로드 성공");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/UMC/campusNote/common/code/status/SuccessStatus.java
+++ b/src/main/java/UMC/campusNote/common/code/status/SuccessStatus.java
@@ -34,7 +34,9 @@ public enum SuccessStatus implements BaseCode {
     AUDIO_DELETE(HttpStatus.OK, "AUDIO202", "녹음 파일 삭제 성공"),
 
     // 강의노트
-    LESSONNOTE_CREATE(HttpStatus.CREATED, "LESSONNOTE201", "강의노트 업로드 성공");
+    LESSONNOTE_CREATE(HttpStatus.CREATED, "LESSONNOTE201", "강의 노트 업로드 성공"),
+    LESSONNOTE_GET(HttpStatus.OK, "LESSONNOTE200", "강의 노트 조회 성공"),
+    LESSONNOTE_DELETE(HttpStatus.OK, "LESSONNOTE202", "강의 노트 삭제 성공");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/UMC/campusNote/lessonNote/controller/LessonNoteController.java
+++ b/src/main/java/UMC/campusNote/lessonNote/controller/LessonNoteController.java
@@ -19,8 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 
-import static UMC.campusNote.common.code.status.SuccessStatus.LESSONNOTE_CREATE;
-import static UMC.campusNote.common.code.status.SuccessStatus.LESSONNOTE_GET;
+import static UMC.campusNote.common.code.status.SuccessStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,6 +46,7 @@ public class LessonNoteController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LESSONNOTE200",description = "강의 노트 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTE4001", description = "존재하지 않는 노트.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LESSONNOTE4001", description = "존재하지 않는 강의 노트.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameters({
             @Parameter(name = "noteId", description = "노트의 아이디, path variable 입니다")
@@ -55,6 +55,22 @@ public class LessonNoteController {
         LessonNote lessonNote = lessonNoteService.getLessonNoteByNoteId(noteId);
         return ApiResponse.of(LESSONNOTE_GET, LessonNoteConverter.toLessonNoteResultDTO(lessonNote));
     }
+
+    @DeleteMapping("/{noteId}")
+    @Operation(summary = "특정 노트의 강의 노트를 삭제하는 API", description = "특정 노트의 강의 노트를 삭제하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LESSONNOTE200",description = "강의 노트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTE4001", description = "존재하지 않는 노트.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LESSONNOTE4001", description = "존재하지 않는 강의 노트.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "noteId", description = "노트의 아이디, path variable 입니다")
+    })
+    public ApiResponse<LessonNoteResponseDTO.lessonNoteResultDTO> deleteLessonNotes(@PathVariable Long noteId) throws IOException {
+        LessonNote lessonNote = lessonNoteService.deleteLessonNoteByNoteId(noteId);
+        return ApiResponse.of(LESSONNOTE_DELETE, LessonNoteConverter.toLessonNoteResultDTO(lessonNote));
+    }
+
 
 
 

--- a/src/main/java/UMC/campusNote/lessonNote/controller/LessonNoteController.java
+++ b/src/main/java/UMC/campusNote/lessonNote/controller/LessonNoteController.java
@@ -1,0 +1,39 @@
+package UMC.campusNote.lessonNote.controller;
+
+import UMC.campusNote.common.ApiResponse;
+import UMC.campusNote.lessonNote.converter.LessonNoteConverter;
+import UMC.campusNote.lessonNote.dto.LessonNoteRequestDTO;
+import UMC.campusNote.lessonNote.dto.LessonNoteResponseDTO;
+import UMC.campusNote.lessonNote.entity.LessonNote;
+import UMC.campusNote.lessonNote.service.LessonNoteService;
+import UMC.campusNote.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import static UMC.campusNote.common.code.status.SuccessStatus.LESSONNOTE_CREATE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/lessonNotes")
+public class LessonNoteController {
+    private final LessonNoteService lessonNoteService;
+    @PostMapping
+    @Operation(summary = "강의 노트 등록 API", description = "request 파라미터로 noteId // image 파라미터로 파일 넣기 ")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LESSONNOTE201",description = "강의 노트 업로드 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTE4001", description = "존재하지 않는 노트.",content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    public ApiResponse<LessonNoteResponseDTO.lessonNoteResultDTO> create(@AuthenticationPrincipal User user, @RequestPart("request") LessonNoteRequestDTO.LessonNoteDTO request, @RequestPart("image") MultipartFile image) throws IOException {
+        LessonNote newLessonNote = lessonNoteService.createLessonNote(request, image, user.getId());
+        return ApiResponse.of(LESSONNOTE_CREATE, LessonNoteConverter.toLessonNoteResultDTO(newLessonNote));
+    }
+}

--- a/src/main/java/UMC/campusNote/lessonNote/controller/LessonNoteController.java
+++ b/src/main/java/UMC/campusNote/lessonNote/controller/LessonNoteController.java
@@ -2,38 +2,61 @@ package UMC.campusNote.lessonNote.controller;
 
 import UMC.campusNote.common.ApiResponse;
 import UMC.campusNote.lessonNote.converter.LessonNoteConverter;
-import UMC.campusNote.lessonNote.dto.LessonNoteRequestDTO;
 import UMC.campusNote.lessonNote.dto.LessonNoteResponseDTO;
 import UMC.campusNote.lessonNote.entity.LessonNote;
 import UMC.campusNote.lessonNote.service.LessonNoteService;
+import UMC.campusNote.page.dto.PageResponseDTO;
 import UMC.campusNote.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
+
 import static UMC.campusNote.common.code.status.SuccessStatus.LESSONNOTE_CREATE;
+import static UMC.campusNote.common.code.status.SuccessStatus.LESSONNOTE_GET;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/lessonNotes")
 public class LessonNoteController {
     private final LessonNoteService lessonNoteService;
-    @PostMapping
-    @Operation(summary = "강의 노트 등록 API", description = "request 파라미터로 noteId // image 파라미터로 파일 넣기 ")
+    @PostMapping("/{noteId}")
+    @Operation(summary = "강의 노트 등록 API", description = "특정 노트의 강의 노트를 등록하는 API ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LESSONNOTE201",description = "강의 노트 업로드 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTE4001", description = "존재하지 않는 노트.",content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTE4001", description = "존재하지 않는 노트.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
-    public ApiResponse<LessonNoteResponseDTO.lessonNoteResultDTO> create(@AuthenticationPrincipal User user, @RequestPart("request") LessonNoteRequestDTO.LessonNoteDTO request, @RequestPart("image") MultipartFile image) throws IOException {
-        LessonNote newLessonNote = lessonNoteService.createLessonNote(request, image, user.getId());
+    @Parameters({
+            @Parameter(name = "noteId", description = "노트의 아이디, path variable 입니다"),
+            @Parameter(name = "lessonNoteFile", description = "강의 노트 파일, Multipart 입니다")
+    })
+    public ApiResponse<LessonNoteResponseDTO.lessonNoteResultDTO> create(@AuthenticationPrincipal User user, @PathVariable("noteId") Long noteId, @RequestParam("lessonNoteFile") MultipartFile lessonNoteFile) throws IOException {
+        LessonNote newLessonNote = lessonNoteService.createLessonNote(noteId, lessonNoteFile, user.getId());
         return ApiResponse.of(LESSONNOTE_CREATE, LessonNoteConverter.toLessonNoteResultDTO(newLessonNote));
     }
+
+    @GetMapping("/{noteId}")
+    @Operation(summary = "특정 노트의 강의 노트를 조회하는 API", description = "특정 노트의 강의 노트를 조회하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LESSONNOTE200",description = "강의 노트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTE4001", description = "존재하지 않는 노트.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "noteId", description = "노트의 아이디, path variable 입니다")
+    })
+    public ApiResponse<LessonNoteResponseDTO.lessonNoteResultDTO> getLessonNotes(@PathVariable Long noteId) throws IOException {
+        LessonNote lessonNote = lessonNoteService.getLessonNoteByNoteId(noteId);
+        return ApiResponse.of(LESSONNOTE_GET, LessonNoteConverter.toLessonNoteResultDTO(lessonNote));
+    }
+
+
+
+
 }

--- a/src/main/java/UMC/campusNote/lessonNote/converter/LessonNoteConverter.java
+++ b/src/main/java/UMC/campusNote/lessonNote/converter/LessonNoteConverter.java
@@ -1,9 +1,7 @@
 package UMC.campusNote.lessonNote.converter;
 
-import UMC.campusNote.lessonNote.dto.LessonNoteRequestDTO;
 import UMC.campusNote.lessonNote.dto.LessonNoteResponseDTO;
 import UMC.campusNote.lessonNote.entity.LessonNote;
-import UMC.campusNote.lessonNote.repository.LessonNoteRepository;
 import UMC.campusNote.note.Note;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,6 +13,7 @@ public class LessonNoteConverter {
         return LessonNoteResponseDTO.lessonNoteResultDTO.builder()
                 .lessonNoteId(lessonNote.getId())
                 .noteId(lessonNote.getNote().getId())
+                .fileUrl(lessonNote.getLessonNote())
                 .build();
     }
 

--- a/src/main/java/UMC/campusNote/lessonNote/converter/LessonNoteConverter.java
+++ b/src/main/java/UMC/campusNote/lessonNote/converter/LessonNoteConverter.java
@@ -1,0 +1,27 @@
+package UMC.campusNote.lessonNote.converter;
+
+import UMC.campusNote.lessonNote.dto.LessonNoteRequestDTO;
+import UMC.campusNote.lessonNote.dto.LessonNoteResponseDTO;
+import UMC.campusNote.lessonNote.entity.LessonNote;
+import UMC.campusNote.lessonNote.repository.LessonNoteRepository;
+import UMC.campusNote.note.Note;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LessonNoteConverter {
+    public static LessonNoteResponseDTO.lessonNoteResultDTO toLessonNoteResultDTO(LessonNote lessonNote){
+        return LessonNoteResponseDTO.lessonNoteResultDTO.builder()
+                .lessonNoteId(lessonNote.getId())
+                .noteId(lessonNote.getNote().getId())
+                .build();
+    }
+
+    public static LessonNote toLessonNote(Note note){
+        return LessonNote.builder()
+                .note(note)
+                .build();
+    }
+
+}

--- a/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteRequestDTO.java
+++ b/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteRequestDTO.java
@@ -1,12 +1,5 @@
 package UMC.campusNote.lessonNote.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
 public class LessonNoteRequestDTO {
-    @Getter
-    public static class LessonNoteDTO{
-        @Schema(description = "노트아이디", example = "1")
-        Long noteId;
-    }
 }

--- a/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteRequestDTO.java
+++ b/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteRequestDTO.java
@@ -1,0 +1,12 @@
+package UMC.campusNote.lessonNote.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+public class LessonNoteRequestDTO {
+    @Getter
+    public static class LessonNoteDTO{
+        @Schema(description = "노트아이디", example = "1")
+        Long noteId;
+    }
+}

--- a/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteResponseDTO.java
+++ b/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteResponseDTO.java
@@ -13,5 +13,6 @@ public class LessonNoteResponseDTO {
     public static class lessonNoteResultDTO{
         Long lessonNoteId;
         Long noteId;
+        String fileUrl;
     }
 }

--- a/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteResponseDTO.java
+++ b/src/main/java/UMC/campusNote/lessonNote/dto/LessonNoteResponseDTO.java
@@ -1,0 +1,17 @@
+package UMC.campusNote.lessonNote.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class LessonNoteResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class lessonNoteResultDTO{
+        Long lessonNoteId;
+        Long noteId;
+    }
+}

--- a/src/main/java/UMC/campusNote/lessonNote/entity/LessonNote.java
+++ b/src/main/java/UMC/campusNote/lessonNote/entity/LessonNote.java
@@ -1,15 +1,13 @@
-package UMC.campusNote.lessonNote;
+package UMC.campusNote.lessonNote.entity;
 
 import UMC.campusNote.common.BaseEntity;
 import UMC.campusNote.note.Note;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/UMC/campusNote/lessonNote/repository/LessonNoteRepository.java
+++ b/src/main/java/UMC/campusNote/lessonNote/repository/LessonNoteRepository.java
@@ -4,6 +4,8 @@ import UMC.campusNote.lessonNote.entity.LessonNote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface LessonNoteRepository extends JpaRepository<LessonNote, Long> {
     LessonNote findByNoteId(Long noteId);

--- a/src/main/java/UMC/campusNote/lessonNote/repository/LessonNoteRepository.java
+++ b/src/main/java/UMC/campusNote/lessonNote/repository/LessonNoteRepository.java
@@ -1,0 +1,10 @@
+package UMC.campusNote.lessonNote.repository;
+
+import UMC.campusNote.lessonNote.entity.LessonNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LessonNoteRepository extends JpaRepository<LessonNote, Long> {
+    LessonNote findByNoteId(Long noteId);
+}

--- a/src/main/java/UMC/campusNote/lessonNote/service/LessonNoteService.java
+++ b/src/main/java/UMC/campusNote/lessonNote/service/LessonNoteService.java
@@ -1,0 +1,52 @@
+package UMC.campusNote.lessonNote.service;
+
+import UMC.campusNote.common.exception.GeneralException;
+import UMC.campusNote.common.s3.S3Provider;
+import UMC.campusNote.common.s3.dto.S3UploadRequest;
+import UMC.campusNote.lessonNote.converter.LessonNoteConverter;
+import UMC.campusNote.lessonNote.dto.LessonNoteRequestDTO;
+import UMC.campusNote.lessonNote.entity.LessonNote;
+import UMC.campusNote.lessonNote.repository.LessonNoteRepository;
+import UMC.campusNote.note.Note;
+import UMC.campusNote.note.NoteRepository;
+import UMC.campusNote.user.entity.User;
+import UMC.campusNote.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static UMC.campusNote.common.code.status.ErrorStatus.NOTE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class LessonNoteService {
+    private final LessonNoteRepository lessonNoteRepository;
+    private final NoteRepository noteRepository;
+    private final UserRepository userRepository;
+    private final S3Provider s3Provider;
+
+    public LessonNote createLessonNote(LessonNoteRequestDTO.LessonNoteDTO request, MultipartFile file, Long userId) throws IOException {
+        User user = userRepository.findById(userId).orElseThrow(()-> new RuntimeException());
+        Note note = noteRepository.findById(request.getNoteId()).orElseThrow(()->  new GeneralException(NOTE_NOT_FOUND));
+
+
+        String fileDir = "lessonNotes/" + request.getNoteId();
+
+        S3UploadRequest s3UploadRequest = new S3UploadRequest(user.getId(), fileDir);
+        String imgUrl = s3Provider.fileUpload(file, s3UploadRequest);
+
+        LessonNote existLessonNote = lessonNoteRepository.findByNoteId(request.getNoteId());
+        if (existLessonNote != null){ // 이미 존재
+            // 강노 업데이트
+            existLessonNote.setLessonNote(imgUrl);
+            return lessonNoteRepository.save(existLessonNote);
+        } else{
+            // 새 강노 생성
+            LessonNote newLessonNote = LessonNoteConverter.toLessonNote(note);
+            newLessonNote.setLessonNote(imgUrl);
+            return lessonNoteRepository.save(newLessonNote);
+        }
+    }
+}

--- a/src/main/java/UMC/campusNote/lessonNote/service/LessonNoteService.java
+++ b/src/main/java/UMC/campusNote/lessonNote/service/LessonNoteService.java
@@ -4,7 +4,6 @@ import UMC.campusNote.common.exception.GeneralException;
 import UMC.campusNote.common.s3.S3Provider;
 import UMC.campusNote.common.s3.dto.S3UploadRequest;
 import UMC.campusNote.lessonNote.converter.LessonNoteConverter;
-import UMC.campusNote.lessonNote.dto.LessonNoteRequestDTO;
 import UMC.campusNote.lessonNote.entity.LessonNote;
 import UMC.campusNote.lessonNote.repository.LessonNoteRepository;
 import UMC.campusNote.note.Note;
@@ -27,17 +26,17 @@ public class LessonNoteService {
     private final UserRepository userRepository;
     private final S3Provider s3Provider;
 
-    public LessonNote createLessonNote(LessonNoteRequestDTO.LessonNoteDTO request, MultipartFile file, Long userId) throws IOException {
+    public LessonNote createLessonNote(Long noteId, MultipartFile file, Long userId) throws IOException {
         User user = userRepository.findById(userId).orElseThrow(()-> new RuntimeException());
-        Note note = noteRepository.findById(request.getNoteId()).orElseThrow(()->  new GeneralException(NOTE_NOT_FOUND));
+        Note note = noteRepository.findById(noteId).orElseThrow(()->  new GeneralException(NOTE_NOT_FOUND));
 
 
-        String fileDir = "lessonNotes/" + request.getNoteId();
+        String fileDir = "lessonNotes/" + noteId;
 
         S3UploadRequest s3UploadRequest = new S3UploadRequest(user.getId(), fileDir);
         String imgUrl = s3Provider.fileUpload(file, s3UploadRequest);
 
-        LessonNote existLessonNote = lessonNoteRepository.findByNoteId(request.getNoteId());
+        LessonNote existLessonNote = lessonNoteRepository.findByNoteId(noteId);
         if (existLessonNote != null){ // 이미 존재
             // 강노 업데이트
             existLessonNote.setLessonNote(imgUrl);
@@ -47,6 +46,15 @@ public class LessonNoteService {
             LessonNote newLessonNote = LessonNoteConverter.toLessonNote(note);
             newLessonNote.setLessonNote(imgUrl);
             return lessonNoteRepository.save(newLessonNote);
+        }
+    }
+
+    public LessonNote getLessonNoteByNoteId(Long noteId) throws GeneralException {
+        LessonNote lessonNote = lessonNoteRepository.findByNoteId(noteId);
+        if (lessonNote == null) {
+            throw new GeneralException(NOTE_NOT_FOUND);
+        } else {
+            return lessonNote;
         }
     }
 }

--- a/src/main/java/UMC/campusNote/lessonNote/service/LessonNoteService.java
+++ b/src/main/java/UMC/campusNote/lessonNote/service/LessonNoteService.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
+import static UMC.campusNote.common.code.status.ErrorStatus.LESSONNOTE_NOT_FOUND;
 import static UMC.campusNote.common.code.status.ErrorStatus.NOTE_NOT_FOUND;
 
 @Service
@@ -50,10 +51,22 @@ public class LessonNoteService {
     }
 
     public LessonNote getLessonNoteByNoteId(Long noteId) throws GeneralException {
+        Note note = noteRepository.findById(noteId).orElseThrow(()-> new GeneralException(NOTE_NOT_FOUND));
         LessonNote lessonNote = lessonNoteRepository.findByNoteId(noteId);
         if (lessonNote == null) {
-            throw new GeneralException(NOTE_NOT_FOUND);
+            throw new GeneralException(LESSONNOTE_NOT_FOUND);
         } else {
+            return lessonNote;
+        }
+    }
+
+    public LessonNote deleteLessonNoteByNoteId(Long noteId) throws GeneralException {
+        Note note = noteRepository.findById(noteId).orElseThrow(()-> new GeneralException(NOTE_NOT_FOUND));
+        LessonNote lessonNote = lessonNoteRepository.findByNoteId(noteId);
+        if (lessonNote == null) {
+            throw new GeneralException(LESSONNOTE_NOT_FOUND);
+        } else {
+            lessonNoteRepository.delete(lessonNote);
             return lessonNote;
         }
     }

--- a/src/main/java/UMC/campusNote/note/Note.java
+++ b/src/main/java/UMC/campusNote/note/Note.java
@@ -3,7 +3,7 @@ package UMC.campusNote.note;
 import UMC.campusNote.audio.entity.Audio;
 import UMC.campusNote.common.BaseEntity;
 import UMC.campusNote.image.Image;
-import UMC.campusNote.lessonNote.LessonNote;
+import UMC.campusNote.lessonNote.entity.LessonNote;
 import UMC.campusNote.mapping.UserLessonNote;
 import UMC.campusNote.page.entity.Page;
 import jakarta.persistence.*;


### PR DESCRIPTION
강의 노트 파일을 저장하는 API 구현

1. 강의 노트 생성
2. 특정 노트 아이디로 강의 노트 조회
3. 특정 노트 아이디로 강의 노트 삭제 